### PR TITLE
Enable user selection of units for Temperature, Barometric Pressure and Wind

### DIFF
--- a/WeatherLink Live.indigoPlugin/Contents/Info.plist
+++ b/WeatherLink Live.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>

--- a/WeatherLink Live.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/WeatherLink Live.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -9,13 +9,6 @@
 			<Option value="C">Celsius</Option>
 		</List>
 	</Field>
-	<Field id="units_rain" type="menu" defaultValue="IN">
-		<Label>Rain Units:</Label>
-		<List>
-			<Option value="IN">Inches</Option>
-			<Option value="MM">Millimetres</Option>
-		</List>
-	</Field>
 	<Field id="units_barometric_pressure" type="menu" defaultValue="IN">
 		<Label>Barometric Pressure Units:</Label>
 		<List>

--- a/WeatherLink Live.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/WeatherLink Live.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -1,6 +1,46 @@
 <?xml version="1.0"?>
 <PluginConfig>
 	<SupportURL>http://forums.indigodomo.com/viewforum.php?f=213</SupportURL>
+	<Field id="space1" type="label"><Label/></Field>
+    <Field id="separator1" type="separator"/>
+    <Field id="space2" type="label"><Label/></Field>
+	<Field id="units_temperature" type="menu" defaultValue="F">
+		<Label>Temperature Units:</Label>
+		<List>
+			<Option value="F">Fahrenheit</Option>
+			<Option value="C">Celsius</Option>
+		</List>
+	</Field>
+	<Field id="units_rain" type="menu" defaultValue="IN">
+		<Label>Rain Units:</Label>
+		<List>
+			<Option value="IN">Inches</Option>
+			<Option value="MM">Millimetres</Option>
+		</List>
+	</Field>
+	<Field id="units_barometric_pressure" type="menu" defaultValue="IN">
+		<Label>Barometric Pressure Units:</Label>
+		<List>
+			<Option value="IN">Inches</Option>
+			<Option value="MM">Millimetres</Option>
+			<Option value="MB">Millibars</Option>
+			<Option value="HP">hectoPascals</Option>
+		</List>
+	</Field>
+	<Field id="units_wind" type="menu" defaultValue="MPH">
+		<Label>Wind Units:</Label>
+		<List>
+			<Option value="MPH">Miles per Hour</Option>
+			<Option value="KNO">Knots</Option>
+			<Option value="KPH">Kilometers per Hour</Option>
+			<Option value="MPS">Meters per Second</Option>
+		</List>
+	</Field>
+
+	<Field id="space3" type="label"><Label/></Field>
+    <Field id="separator2" type="separator"/>
+    <Field id="space4" type="label"><Label/></Field>
+
 	<Field id="logLevel" type="menu" defaultValue="20">
 		<Label>Event Logging Level:</Label>
 		<List>

--- a/WeatherLink Live.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/WeatherLink Live.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -2,8 +2,6 @@
 <PluginConfig>
 	<SupportURL>http://forums.indigodomo.com/viewforum.php?f=213</SupportURL>
 	<Field id="space1" type="label"><Label/></Field>
-    <Field id="separator1" type="separator"/>
-    <Field id="space2" type="label"><Label/></Field>
 	<Field id="units_temperature" type="menu" defaultValue="F">
 		<Label>Temperature Units:</Label>
 		<List>
@@ -37,9 +35,9 @@
 		</List>
 	</Field>
 
-	<Field id="space3" type="label"><Label/></Field>
+	<Field id="space2" type="label"><Label/></Field>
     <Field id="separator2" type="separator"/>
-    <Field id="space4" type="label"><Label/></Field>
+    <Field id="space3" type="label"><Label/></Field>
 
 	<Field id="logLevel" type="menu" defaultValue="20">
 		<Label>Event Logging Level:</Label>


### PR DESCRIPTION
Reflect these selections in device states.

Thanks for the opportunity to incorporate these changes into thye official version. :)

Also added in an Indigo Import in try/except block as PyCharm which I used for the change was showing an error. removed unused import statements (identified by PyCharm).

I have done basic testing by changing settings in the Weather Link App and in the plugin and then comparing values. :)

btw - The multiple commits was because I was checking through the pull-request code changes and spotted minor things that I should have sorted out before pushing. ;)
